### PR TITLE
Replace instances of `Object` with `object` in type defs

### DIFF
--- a/foundrytypes/ClientSettings.d.ts
+++ b/foundrytypes/ClientSettings.d.ts
@@ -9,7 +9,7 @@ declare class ClientSettings {
 
 }
 
-interface SettingConfig<T extends typeof String | typeof Number | typeof Boolean | typeof Object> {
+interface SettingConfig<T extends typeof String | typeof Number | typeof Boolean | typeof object> {
 	name: string;
 	hint: string;
 	scope: "client" | "world";

--- a/foundrytypes/data/fields/FoundryDataFields.d.ts
+++ b/foundrytypes/data/fields/FoundryDataFields.d.ts
@@ -119,7 +119,7 @@ type NoInfer<A>= [A][A extends any ? 0 : never]
 type NoArray<I>= I extends Array<infer T> ? Record<number, T> : I;
 type DeepNoArray<I>=
 	I extends Array<infer J> ? NoArray<Array<DeepNoArray<J>>> :
-	I extends Object ? { [k in keyof I]: DeepNoArray<I[k]>} :
+	I extends object ? { [k in keyof I]: DeepNoArray<I[k]>} :
 	I;
 
 

--- a/foundrytypes/globalfunc.d.ts
+++ b/foundrytypes/globalfunc.d.ts
@@ -1,5 +1,5 @@
 /** @deprecated in V12: use foundry.utils.mergeObject instead */
-declare function mergeObject<A extends Object,B extends Object>( a: A, b: B) : B&A;
+declare function mergeObject<A extends object,B extends object>( a: A, b: B) : B&A;
 
 
 declare function renderTemplate(templatePath: string, templateData: Record<string|number, any>): Promise<string>;

--- a/foundrytypes/roll.d.ts
+++ b/foundrytypes/roll.d.ts
@@ -20,7 +20,7 @@ class Roll {
 	options: RollOptions;
 	toJSON(): string;
 	static fromJSON<T extends Roll= Roll>(json: string): T;
-	static fromData<T extends Roll= Roll>(obj: Object): T;
+	static fromData<T extends Roll= Roll>(obj: object): T;
 	toAnchor(...stuff : unknown[]): HTMLElement;
 	_evaluated: boolean;
 }

--- a/foundrytypes/sheets/sheet.d.ts
+++ b/foundrytypes/sheets/sheet.d.ts
@@ -14,7 +14,7 @@ class Sheet<T extends FoundryDocument<any>> extends FormApplication {
 
 
 class FormApplication extends Application {
-	constructor(object: Object={}, options:Object ={});
+	constructor(object: object={}, options:object ={});
 	getData(options : Record<string, unknown> = {}): AppData | Promise<AppData>;
 
 	close( options?: unknown): void;

--- a/foundrytypes/util/util.d.ts
+++ b/foundrytypes/util/util.d.ts
@@ -17,11 +17,11 @@ interface FoundryUtil {
 			lineLineIntersection(a: Point, b: Point, c: Point,d: Point, options:unknown): unknown,
 			lineSegmentIntersection(...args: unknown[]): unknown,
 			lineSegmentIntersects(...args: unknown[]): unknown,
-			mergeObject<A extends Object, B extends Object>(original: A, other: B={}, {insertKeys=true, insertValues=true, overwrite=true, recursive=true, inplace=true, enforceTypes=false,
+			mergeObject<A extends object, B extends object>(original: A, other: B={}, {insertKeys=true, insertValues=true, overwrite=true, recursive=true, inplace=true, enforceTypes=false,
 
 				      performDeletions=false}: MergeOptions = {}): A&B,
 		randomId(length =16) : string,
-		expandObject(obj : Object): Object;
+		expandObject(obj : object): object;
 
 	/**
  * Wrap a callback in a debounced timeout.


### PR DESCRIPTION
My linter highlighted this nitpick while I was troubleshooting another bug (not sure if it's with your types or not atm): TS prefers `object` to `Object` in type definitions, like with `number` vs. `Number` etc. I'll submit another PR if I find a real problem XD