### PR TITLE
Add parameters to Roll.toMessage

### DIFF
--- a/foundrytypes/roll.d.ts
+++ b/foundrytypes/roll.d.ts
@@ -13,7 +13,7 @@ class Roll {
 
 	get total(): number;
 	get result(): string;
-	async toMessage(): Promise<ChatMessage>;
+	async toMessage(MessageData: Partial<ChatMessageData>={}, {rollMode, create=true }: RollChatMessageOptions={}): Promise<ChatMessage>;
 	get dice(): Die[];
 	terms: RollTerm[];
 	formula: string;
@@ -89,3 +89,27 @@ default: true
 
 type RollTerm = Die | OperatorTerm | NumericTerm;
 
+// TODO: Figure out how to derive this from CONST.DICE_ROLL_MODES
+// instead of using literal strings
+type RollMode = "publicroll" | "gmroll" | "blindroll" | "selfroll";
+
+interface RollChatMessageOptions {
+	rollMode?: RollMode;
+	create?: boolean;
+}
+
+interface ChatMessageData {
+	_id: string;
+	type: number;
+	user: string;
+	timestamp: number;
+	flavor: string;
+	content: string;
+	speaker: ChatSpeakerObject;
+	whisper: string[];
+	blind: boolean;
+	rolls: string[];
+	sound: string;
+	emote: boolean;
+	flags: object;
+}


### PR DESCRIPTION
While trying to relearn how to display dice rolls in chat cards, I ran across some missing parameter definitions for the toMessage method on the Roll class. It took me a little digging to find them, but they should be correct. I assume it should be possible to derive the values for the RollMode type from CONST.DICE_ROLL_MODES, but I'm sleepy and what I have works for now XD