### PR TITLE
Fix SettingConfig interface

### DIFF
--- a/foundrytypes/ClientSettings.d.ts
+++ b/foundrytypes/ClientSettings.d.ts
@@ -5,7 +5,7 @@ declare class ClientSettings {
 	register<T extends typeof String | typeof Number | typeof Boolean>(namespace: string, key: string, data: SettingConfig<T> ): void;
 	registerMenu<C extends typeof FormApplication>(namespace:string, key: string, data: SettingSubmenuConfig<C>): void;
 	get<Output = unknown>(namespace: string, key: string): Output;
-	async set(namespace:string, key: string, value: unkwown): Promise<void>
+	async set(namespace:string, key: string, value: unknown): Promise<void>
 
 }
 
@@ -21,7 +21,7 @@ interface SettingConfig<T extends typeof String | typeof Number | typeof Boolean
 	default: InstanceType<T>;
 	onChange?: (newval: InstanceType<T>) => void;
 	/** Restrict this submenu to gamemaster only? */
-	restricted: boolean
+	restricted?: boolean
 }
 
 


### PR DESCRIPTION
The `restricted` attribute on the `SettingConfig` interface is optional and false by default. This conforms to the Foundry docs and behavior; I tested it with a dummy user. I also fixed a typo XD