### PR TITLE
Add render method signature to Roll class

### DIFF
--- a/foundrytypes/roll.d.ts
+++ b/foundrytypes/roll.d.ts
@@ -18,6 +18,7 @@ class Roll {
 	terms: RollTerm[];
 	formula: string;
 	options: RollOptions;
+	async render({ flavor, template, isPrivate }: RollRenderOptions={}): Promise<string>;
 	toJSON(): string;
 	static fromJSON<T extends Roll= Roll>(json: string): T;
 	static fromData<T extends Roll= Roll>(obj: Object): T;
@@ -89,3 +90,8 @@ default: true
 
 type RollTerm = Die | OperatorTerm | NumericTerm;
 
+interface RollRenderOptions {
+	flavor?: string;
+	template?: string;
+	isPrivate?: boolean;
+}


### PR DESCRIPTION
The Roll class was missing the render() method signature so I added it. It might not be the correct way to do what I've been doing with it, but it can't hurt to have it XD