### PR TITLE
Add preCreateActor and preCreateItem hooks

### DIFF
--- a/foundrytypes/hooks.d.ts
+++ b/foundrytypes/hooks.d.ts
@@ -15,6 +15,8 @@ declare interface HOOKS {
 	"combatTurn": (combat: Combat, updateData: CombatUpdateData, updateOptions: CombatUpdateOptions) => unknown;
 	"combatRound": (combat: Combat, updateData: CombatUpdateData, updateOptions: CombatUpdateOptions) => unknown;
 	"chatMessage": (chatLog: ChatLog, contents: string, chatMsgData: unknown) => unknown;
+	"preCreateActor": PreCreateHook<Actor>;
+	"preCreateItem": PreCreateHook<Item>;
 	"preCreateChatMessage": PreCreateHook<ChatMessage>;
 	"createChatMessage": CreateHook<ChatMessage>;
 	"preUpdateActor": UpdateHook<Actor>;


### PR DESCRIPTION
While I was mucking around today trying to figure out how to do stuff, I noticed missing hooks for preCreateActor and preCreateItem. Should be fixed now!