### PR TITLE
Add DatabaseOperation type

### DIFF
--- a/foundrytypes/abstract/foundryabstract.d.ts
+++ b/foundrytypes/abstract/foundryabstract.d.ts
@@ -6,19 +6,13 @@ interface FoundryAbstract {
 interface DatabaseCreateOperation {
 	broadcast?: boolean;
 	data?: object[];
-	// Default: false
-	keepId?: boolean;
-	// Default: true
-	keepEmbeddedIds?: boolean;
+	keepId?: boolean; // Default: false
+	keepEmbeddedIds?: boolean; // Default: true
 	modifiedTime?: number;
-	// Default: false
-	noHook?: boolean;
-	// Default: true
-	render?: boolean;
-	// Default: false
-	renderSheet?: boolean;
-	// Default: null
-	parent?: any;
+	noHook?: boolean; // Default: false
+	render?: boolean; // Default: true
+	renderSheet?: boolean; // Default: false
+	parent?: any; // Default: null
 	pack?: string | null;
 	parentUuid?: string | null;
 	_result?: (string | object)[];

--- a/foundrytypes/abstract/foundryabstract.d.ts
+++ b/foundrytypes/abstract/foundryabstract.d.ts
@@ -3,4 +3,23 @@ interface FoundryAbstract {
 	TypeDataModel : typeof TypeDataModelClass;
 }
 
-
+interface DatabaseCreateOperation {
+	broadcast?: boolean;
+	data?: object[];
+	// Default: false
+	keepId?: boolean;
+	// Default: true
+	keepEmbeddedIds?: boolean;
+	modifiedTime?: number;
+	// Default: false
+	noHook?: boolean;
+	// Default: true
+	render?: boolean;
+	// Default: false
+	renderSheet?: boolean;
+	// Default: null
+	parent?: any;
+	pack?: string | null;
+	parentUuid?: string | null;
+	_result?: (string | object)[];
+}

--- a/foundrytypes/abstract/foundryabstract.d.ts
+++ b/foundrytypes/abstract/foundryabstract.d.ts
@@ -2,18 +2,3 @@ interface FoundryAbstract {
 	DataModel: typeof DataModelClass;
 	TypeDataModel : typeof TypeDataModelClass;
 }
-
-interface DatabaseCreateOperation {
-	broadcast?: boolean;
-	data?: object[];
-	keepId?: boolean; // Default: false
-	keepEmbeddedIds?: boolean; // Default: true
-	modifiedTime?: number;
-	noHook?: boolean; // Default: false
-	render?: boolean; // Default: true
-	renderSheet?: boolean; // Default: false
-	parent?: any; // Default: null
-	pack?: string | null;
-	parentUuid?: string | null;
-	_result?: (string | object)[];
-}

--- a/foundrytypes/abstract/types/DatabaseOperation.d.ts
+++ b/foundrytypes/abstract/types/DatabaseOperation.d.ts
@@ -1,0 +1,54 @@
+type DatabaseOperation = DatabaseGetOperation | DatabaseCreateOperation | DatabaseUpdateOperation | DatabaseDeleteOperation;
+
+interface DatabaseGetOperation {
+	query?: Record<string, any>;
+	broadcast?: false;
+	index?: boolean;
+	indexFields?: string[];
+	pack?: string; // Default: null
+	parent?: any; // Source code comments say `foundry.abstract.Document | null`
+	parentUuid?: string;
+}
+
+interface DatabaseCreateOperation {
+	broadcast?: boolean;
+	data?: object[];
+	keepId?: boolean; // Default: false
+	keepEmbeddedIds?: boolean; // Default: true
+	modifiedTime?: number;
+	noHook?: boolean; // Default: false
+	render?: boolean; // Default: true
+	renderSheet?: boolean; // Default: false
+	parent?: any; // Source code comments say `foundry.abstract.Document | null`
+	pack?: string | null;
+	parentUuid?: string | null;
+	_result?: (string | object)[];
+}
+
+interface DatabaseUpdateOperation {
+	broadcast?: boolean;
+	data?: object[];
+	keepId?: boolean; // Default: false
+	keepEmbeddedIds?: boolean; // Default: true
+	modifiedTime?: number;
+	noHook?: boolean; // Default: false
+	render?: boolean; // Default: true
+	renderSheet?: boolean // Default: false
+	parent?: any; // Source code comments say `foundry.abstract.Document | null`
+	pack?: string | null;
+	parentUuid?: string | null;
+	_result: (string | object)[];
+}
+
+interface DatabaseDeleteOperation {
+	broadcast?: boolean;
+	ids?: string[];
+	deleteAll?: boolean; // Default: false
+	modifiedTime?: number;
+	noHook?: boolean; // Default: false
+	render?: boolean; // Default: true
+	parent?: any; // Source code comments say `foundry.abstract.Document | null`
+	pack?: string | null;
+	parentUuid?: string | null;
+	_result?: (string | object)[];
+}


### PR DESCRIPTION
I noticed that DatabaseCreateOperation is part of a whole union type of similar interfaces, so I went ahead and added them all. Not sure where they should go in the filesystem, so please feel free to edit accordingly XD Also, according to the comments in the actual source code, the type for the `parent` attribute should be `foundry.abstract.Document | null` and not `any`, but I wasn't sure how to represent that.