### PR TITLE
Active effect change fix

### DIFF
--- a/foundrytypes/active-effect.d.ts
+++ b/foundrytypes/active-effect.d.ts
@@ -29,9 +29,8 @@ type EffectDuration = {
 }
 
 type AEChange = {
-	effect: ActiveEffect<any>;
 	key: string; //keys to one of the system values
-	mode: typeof CONST["ACTIVE_EFFECT_MODES"][keyof typeof CONST["ACTIVE_EFFECT_MODES"]],
-	priority: number,
-	value: string,
-}
+	mode: (typeof CONST)["ACTIVE_EFFECT_MODES"][keyof (typeof CONST)["ACTIVE_EFFECT_MODES"]];
+	priority?: number;
+	value: string;
+};


### PR DESCRIPTION
Small fix to the type for active effect changes: `priority` has a default, so you don't have to specify it. Also, the `effect` attribute isn't actually on the type according to the docs, so it's not necessary unless you need it for an internal hack: <https://foundryvtt.com/api/interfaces/foundry.types.EffectChangeData.html>