### PR TITLE
Add uuid field to FoundryDocument

### DIFF
--- a/foundrytypes/document.d.ts
+++ b/foundrytypes/document.d.ts
@@ -4,6 +4,7 @@
 	async update<T extends updateObj> (updateData: AllowedUpdateKeys<T>): Promise<this>;
 	 // async update(updateData: RecursivePartial< typeof this>): Promise<this>
 
+	 get uuid(): string;
 	 name: string;
 	 id: string;
 	 get pack(): string | null;


### PR DESCRIPTION
FoundryDocument didn't have no uuid field and it needed one and now it got one